### PR TITLE
Provide the willdurand/geocoder repo but on dev-bownty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "provide": {
+        "willdurand/geocoder" : "dev-bownty"  
+    },
     "require-dev": {
         "kriswallsmith/buzz": "@stable",
         "guzzle/guzzle": "@stable",


### PR DESCRIPTION
The ankr/geotools require willdurand/geocoder on a dev-bownty branch.
That branch does not exist in packagist, github or our satis mirror (anymore).
By telling composer that ankr/geocoder provides willdurand/geocoder#dev-bownty
we can continue to refer to willdurand/geocoder.
Alternatively require ankr/geocoder instead of willdurand/geocoder in ankr/geotools
would also work.

This PR has been tested from my patch-1 branch and resolves composer deps correctly.